### PR TITLE
Jestify

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "babel-cli": "^6.18.0",
     "babel-jest": "^18.0.0",
     "babel-preset-es2015": "^6.9.0",
-    "expect": "^1.20.2",
     "jest": "^18.1.0",
     "redux": "^3.6.0",
     "xstream": "^9.0.0"


### PR DESCRIPTION
@lmatteis : Couple of thing I missed while reviewing the Jest tests:
- As Jest is bulit on top of Jasmine come with [full batteries](https://facebook.github.io/jest/docs/api.html#writing-assertions-with-expect), so no need for 3rd assertions library deps.
- Jest comes with [timer mocks](https://facebook.github.io/jest/docs/timer-mocks.html), used this to mock the setInterval internally used by xs.periodic and ffw 10secs :)